### PR TITLE
Add support for the `document_title` filter

### DIFF
--- a/uncapitalize-p.php
+++ b/uncapitalize-p.php
@@ -21,6 +21,7 @@ add_action(
             'the_content' => 11,
             'comment_text' => 31,
             'widget_text_content' => 11,
+            'document_title' => 11,
         ];
         foreach ($filters as $filter => $priority) {
             remove_filter($filter, 'capital_P_dangit', $priority);


### PR DESCRIPTION
This filter will be part of the upcoming WordPress 5.8 release.

See https://core.trac.wordpress.org/changeset/51019

